### PR TITLE
Refactorings and added ability to subscribe to topics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ jspm_packages
 
 # Mac files
 .DS_Store
+/.vs

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ The idea of creating HTTP to MQTT bridge appeared when I was trying to integrate
 
 The HTTP to MQTT bridge should feel that gap. The idea is to receive signals using HTTP requests and transfer them to your MQTT broker, which is connected to HA. The HTTP to MQTT bridge is written using Node JS with [Express](https://expressjs.com/) for HTTP server and [MQTT.js](https://www.npmjs.com/package/mqtt) client.
 
-The app could be hosted on any Node JS hosting. I prefer [Heroku: Cloud Application Platform](https://www.heroku.com/home) for its simplicity.  
+## Usage
 
-## Bringing pieces together
+The app could be hosted on any Node JS hosting. 
+
+### Heroku
+
+I prefer [Heroku: Cloud Application Platform](https://www.heroku.com/home) for its simplicity.  
 
 1. Configure Home Assistant [MQTT trigger](https://home-assistant.io/docs/automation/trigger/#mqtt-trigger).
 1. Configure [CloudMQTT](https://www.cloudmqtt.com/). Here is a great video tutorial on how to do that: https://www.youtube.com/watch?v=VaWdvVVYU3A
@@ -23,14 +27,16 @@ The app could be hosted on any Node JS hosting. I prefer [Heroku: Cloud Applicat
    * Content Type: application/json
    * Body: {"topic":"<mqtt_topic>","message":"<mqtt_message>","key":"<AUTH_KEY>"}
    
-## Subscribe to latest version
+#### Subscribe to latest version
 
 Additionally you can make Heroku to update HTTP to MQTT bridge app to the latest available version from GitHub repository automatically. To do this follow the instruction on [Heroku help page](https://devcenter.heroku.com/articles/github-integration#automatic-deploys).
 
-## Improve response time
+#### Improve response time
 
 After 30 minutes of inactivity Heroku will put your app into sleep mode. This will result in ~10 seconds response time. To prevent Heroku from putting your app into sleep mode ping it every 10 minutes or so. You can do that by sending regular HTTP GET request to http://your_app/keep_alive/. But be carefull. Heroku free quota is 550 hours per month. Without sleeping your app will be allowed to run only 22 days a month. Additionally keep_alive method will send a simple MQTT message to prevent the broker from sleeping as well. The topic and message can be configured using Heroku environment variables KEEP_ALIVE_TOPIC and KEEP_ALIVE_MESSAGE and both are set to “keep_alive” by default.
 
+
+##### Home Assistant Setup
 You can even configure HA to ping HTTP to MQTT bridge every 10 minutes during daytime. Below is an example of how to do that:
 
 ```yaml
@@ -51,6 +57,101 @@ automation:
     before: '23:59:59'
   action:
     service: rest_command.http_to_mqtt_keep_alive
+```
+
+### Use Your Own Server
+You can run this on basically anything that runs NodeJS.
+
+1.  Clone the repository
+2.  Run index.js
+
+#### Examples
+
+
+##### Publish to a topic
+Clone the repository and run `http_to_mqtt`.
+
+By default the `http_to_mqtt` will listen on port 5000 and connect to the localhost MQTT Broker.  
+The MQTT Broker (and other settings) can be specified by environment variables.
+
+```bash
+git clone https://github.com/petkov/http_to_mqtt.git
+cd http_to_mqtt
+node index.js
+```
+
+output:
+```
+Node app is running on port 5000
+```
+
+Publish a message to the topic 'MyTopic'
+```bash
+curl -H "Content-Type: application/json" "http://localhost:5000/post"  -d '{"topic" : "MyTopic", "message" : "Hello World" }'
+```
+
+output:
+```
+OK
+```
+
+#### Subscribe to a topic
+
+You can subscribe to a topic.  `http_to_mqtt` will keep the connection open and wait for a messages from the MQTT Broker and will send them to the response each time a message is handled.
+
+```bash
+git clone https://github.com/petkov/http_to_mqtt.git
+cd http_to_mqtt
+node index.js
+```
+
+output:
+```
+Node app is running on port 5000
+```
+
+Publish a message to the topic 'MyTopic'.  Use `-ivs --raw` to see messages come in as they are received.
+```bash
+curl -ivs --raw localhost:5000/subscribe?topic=MyTopic
+```
+
+output:
+```
+*   Trying ::1...
+* TCP_NODELAY set
+* Connected to localhost (::1) port 5000 (#0)
+> GET /subscribe?topic=MyTopic HTTP/1.1
+> Host: localhost:5000
+> User-Agent: curl/7.54.1
+> Accept: */*
+>
+```
+
+Whenever a message is published to the topic MyTopic curl will output the message.
+
+Use mosquitto_pub to publish a message:
+```bash
+mosquitto_pub -t 'MyTopic' -m 'I sent this message using Mosquitto'
+```
+
+curl output:
+```
+<
+23
+I sent this message using Mosquitto
+```
+
+## Specific Use Cases
+### Plex
+Plex has the ability to specify web hooks.
+
+We must use some query parameters to tell http_to_mqtt to handle certain things specific to our use case.
+ - topic=/plex/playback : Since Plex does not know which MQTT topic to post to, we must specify that via the topic query parameter.  This can be anything.
+ - single=thumb : Plex send the user's thumbnail as the 'thumb' file.  Setting the single query parameter tells http_to_mqtt to handle single file uploads.
+ - path=payload : The information we care about is specified by the payload property of the JSON uploaded.  Tell http_to_mqtt that that is the message that should be published.
+ 
+```
+http://localhost:5000/post?topic=/plex/playback&single=thumb&path=payload
 ```
 
 ## Thanks

--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ var keep_alive_message = process.env.KEEP_ALIVE_MESSAGE || 'keep_alive';
 var mqtt = require('mqtt');
 var express = require('express');
 var bodyParser = require('body-parser');
+var multer  = require('multer')
+
+var upload = multer({ dest: '/tmp/' });
 
 var app = express();
 
@@ -18,6 +21,7 @@ function logRequest(req) {
            req.connection.remoteAddress;
   var message = 'Received request [' + req.originalUrl + 
               '] from [' + ip + ']';
+
   if (debug_mode) {
     message += ' with payload [' + JSON.stringify(req.body) + ']';
   } else {
@@ -41,7 +45,7 @@ app.get('/keep_alive/', function(req, res) {
   res.send('ok');
 });
 
-app.get('/publish', function (req, res) {
+app.post('/publish', upload.single('thumb'), function (req, res) {
     logRequest(req);
 
     var topic = req.query.topic;
@@ -50,24 +54,7 @@ app.get('/publish', function (req, res) {
         res.send('error');
     }
     else {
-        var message = req.body;
-
-        client.publish(topic, message);
-
-        res.send('ok');
-    }
-});
-
-app.post('/publish', function (req, res) {
-    logRequest(req);
-
-    var topic = req.query.topic;
-
-    if (!topic) {
-        res.send('error');
-    }
-    else {
-        var message = req.body;
+        var message = req.body.payload;
 
         client.publish(topic, message);
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var settings = {
         host: process.env.MQTT_HOST || '',
         user: process.env.MQTT_USER || '',
         password: process.env.MQTT_PASS || '',
-        clientId: process.env.MQTT_CLIENT_ID || null;
+        clientId: process.env.MQTT_CLIENT_ID || null
     },
     keepalive: {
         topic: process.env.KEEP_ALIVE_TOPIC || 'keep_alive',

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var multer = require('multer');
 
 var app = express();
 
-function getMqttClient () {
+function getMqttClient() {
 
     var options = {
         username: settings.mqtt.user,
@@ -123,13 +123,13 @@ app.get('/subscribe/', logRequest, authorizeUser, function (req, res) {
         // get a new mqttClient
         // so we dont constantly add listeners on the 'global' mqttClient
         var mqttClient = getMqttClient();
-        
-        mqttClient.on('connect', function () { 
-            mqttClient.subscribe(topic); 
+
+        mqttClient.on('connect', function () {
+            mqttClient.subscribe(topic);
         });
 
         mqttClient.on('message', function (t, m) {
-            if (t === topic){
+            if (t === topic) {
                 res.write(m);
             }
         });

--- a/index.js
+++ b/index.js
@@ -57,6 +57,18 @@ app.post('/publish', function (req, res, next) {
     }
 });
 
+app.post('/publish', function (req, res, next) {
+    console.log('checking for message path...')
+    if (req.query.path) {
+        console.log('Path == ' + req.query.path)
+        req.body = req.body[req.query.path];
+    }
+    else {
+        console.log('No Path')
+    }
+    next();
+});
+
 app.post('/publish', function (req, res) {
     logRequest(req);
 
@@ -66,7 +78,7 @@ app.post('/publish', function (req, res) {
         res.status(500).send('Topic not specified');
     }
     else {
-        var message = req.body;
+        var message = req.body.payload;
 
         client.publish(topic, message);
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var multer = require('multer');
 
 var app = express();
 
-var mqttClient = (function getMqttClient () {
+function getMqttClient () {
 
     var options = {
         username: settings.mqtt.user,
@@ -33,7 +33,9 @@ var mqttClient = (function getMqttClient () {
     }
 
     return mqtt.connect(settings.mqtt.host, options);
-})();
+}
+
+var mqttClient = getMqttClient();
 
 app.set('port', settings.http_port);
 app.use(bodyParser.json());
@@ -118,17 +120,19 @@ app.get('/subscribe/', logRequest, authorizeUser, function (req, res) {
         res.status(500).send('topic not specified');
     }
     else {
-        
-        // get a new mqtt client
-        // so we dont constantly add listeners on the 'global' client
+        // get a new mqttClient
+        // so we dont constantly add listeners on the 'global' mqttClient
         var mqttClient = getMqttClient();
         
-        mqttClient.on('connect', function () { mqttClient.subscribe(topic); });
+        mqttClient.on('connect', function () { 
+            mqttClient.subscribe(topic); 
+        });
+
         mqttClient.on('message', function (t, m) {
-            if (t == topic) {
+            if (t === topic){
                 res.write(m);
             }
-        })
+        });
 
         req.on("close", function () {
             mqttClient.end();

--- a/index.js
+++ b/index.js
@@ -44,12 +44,15 @@ app.get('/keep_alive/', function (req, res) {
 });
 
 app.post('/publish', function (req, res, next) {
+    console.log('checking for single...')
     if (req.query.single) {
+        console.log('Single == ' + req.query.single)
         var upload = multer().single(req.query.single);
 
         upload(req, res, next);
     }
     else {
+        console.log('No Single')
         next();
     }
 });
@@ -63,7 +66,7 @@ app.post('/publish', function (req, res) {
         res.status(500).send('Topic not specified');
     }
     else {
-        var message = req.body.payload;
+        var message = req.body;
 
         client.publish(topic, message);
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,40 @@ app.get('/keep_alive/', function(req, res) {
   res.send('ok');
 });
 
+app.get('/publish', function (req, res) {
+    logRequest(req);
+
+    var topic = req.query.topic;
+
+    if (!topic) {
+        res.send('error');
+    }
+    else {
+        var message = req.body;
+
+        client.publish(topic, message);
+
+        res.send('ok');
+    }
+});
+
+app.post('/publish', function (req, res) {
+    logRequest(req);
+
+    var topic = req.query.topic;
+
+    if (!topic) {
+        res.send('error');
+    }
+    else {
+        var message = req.body;
+
+        client.publish(topic, message);
+
+        res.send('ok');
+    }
+});
+
 app.post('/post/', function(req, res) {
   logRequest(req);
   if (!auth_key || req.body['key'] != auth_key) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ app.set('port', http_port);
 app.use(bodyParser.json());
 
 function authorizeUser(req, res, next) {
-    if (!auth_key || req.body['key'] != auth_key) {
+    if (auth_key && req.body['key'] != auth_key) {
         console.log('Request is not authorized.');
         res.sendStatus(401);
     }

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function checkTopicQueryParameter(req, res, next) {
 }
 
 function ensureTopicSpecified(req, res, next) {
-    if (!body.topic) {
+    if (!req.body.topic) {
         res.status(500).send('Topic not specified');
     }
     else {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "body-parser": "^1.17.1",
     "express": "4.13.3",
-    "mqtt": "^2.5.0"
+    "mqtt": "^2.5.0",
+    "multer" : "1.3.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "HTTP to MQTT bridge",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {


### PR DESCRIPTION
I was going to write a node app to handle my need to publish to my MQTT broker from my Plex server using Plex's webhooks feature.  Instead of reinventing the wheel, I came across your project, forked it, and added what I needed.

Things I did:
 - Refactored much of what you had written as middleware where appropriate.
 - Ability to specify the topic from query parameter
 - Ability to specify the message path from query parameter
 - Ability to specify uploaded files (needed for my case with Plex Webhooks)
 - Feature to subscribe to topics.  This will tell the MQTT Client to subscribe to the topic specified and will proxy any message received to the HTTP response.  I did this just because I thought it would be easy to do.

Nothing I did should have modified existing behavior.  Of course you may want to doublecheck that :).